### PR TITLE
Adding RCov

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -35,6 +35,10 @@ h4. Integration Testing
 
 * "Cucumber":http://github.com/aslakhellesoy/cucumber-rails (optional)
 
+h4. Code Coverage Test
+
+* "RCov":http://github.com/relevance/rcov (optional, only for Ruby 1.8)
+
 h3. JavaScript
 
 * "jQuery":http://jquery.com/

--- a/lib/template_framework/recipes/cover_me.rb
+++ b/lib/template_framework/recipes/cover_me.rb
@@ -1,0 +1,8 @@
+if templater.testing_framework.rspec?
+  gem 'cover_me', '>= 1.0.0.rc5', :group => :test
+
+  templater.post_bundler do
+    generate "cover_me:install"
+    inject_into_file 'spec/spec_helper.rb', "\nrequire 'cover_me'", :after => "ENV[\"RAILS_ENV\"] ||= 'test'"
+  end
+end

--- a/lib/template_framework/recipes/rcov.rb
+++ b/lib/template_framework/recipes/rcov.rb
@@ -1,0 +1,1 @@
+gem "rcov", :group => [:development]

--- a/lib/template_framework/recipes/rspec.rb
+++ b/lib/template_framework/recipes/rspec.rb
@@ -19,7 +19,9 @@ templater.post_bundler do
 end
 
 apply(templater.recipe('remarkable')) if yes?("\n\nWould you like to add Remarkable RSpec matchers? [y|n]: ", Thor::Shell::Color::BLUE)
-if RUBY_VERSION < "1.9"
-  apply(templater.recipe('rcov')) if yes?("\n\nWould you like to add RCov for code coverage? [y|n]: ", Thor::Shell::Color::BLUE)
+if RUBY_VERSION >= "1.9"
+  apply(templater.recipe('cover_me')) if yes?("\n\nWould you like to add CoverMe for code coverage test? [y|n]: ", Thor::Shell::Color::BLUE)
+else
+  apply(templater.recipe('rcov')) if yes?("\n\nWould you like to add RCov for code coverage test? [y|n]: ", Thor::Shell::Color::BLUE)
 end
 apply templater.recipe('factory_girl')

--- a/lib/template_framework/recipes/rspec.rb
+++ b/lib/template_framework/recipes/rspec.rb
@@ -19,4 +19,7 @@ templater.post_bundler do
 end
 
 apply(templater.recipe('remarkable')) if yes?("\n\nWould you like to add Remarkable RSpec matchers? [y|n]: ", Thor::Shell::Color::BLUE)
+if RUBY_VERSION < "1.9"
+  apply(templater.recipe('rcov')) if yes?("\n\nWould you like to add RCov for code coverage? [y|n]: ", Thor::Shell::Color::BLUE)
+end
 apply templater.recipe('factory_girl')

--- a/lib/template_framework/templates/git/gitignore
+++ b/lib/template_framework/templates/git/gitignore
@@ -6,3 +6,4 @@ public/cache/
 public/stylesheets/compiled/
 public/system/*
 tmp/restart.txt
+coverage/


### PR DESCRIPTION
Only for Ruby 1.8 because 1.9 isn't well supported in last rcov gem version.

Edit: Added CoverMe for Ruby 1.9
