### PR TITLE
Fixing Erb option

### DIFF
--- a/lib/template_framework/recipes/template_engine.rb
+++ b/lib/template_framework/recipes/template_engine.rb
@@ -4,7 +4,7 @@ template_engine_options = {
   'Option' => 'Template Engine',
   '1' => 'Haml',
   '2' => 'Slim',
-  '3' => 'ERb',
+  '3' => 'Erb',
 }
 
 print_table template_engine_options.to_a, :ident => 4

--- a/lib/template_framework/recipes/template_engine.rb
+++ b/lib/template_framework/recipes/template_engine.rb
@@ -4,14 +4,14 @@ template_engine_options = {
   'Option' => 'Template Engine',
   '1' => 'Haml',
   '2' => 'Slim',
-  '3' => 'Erb',
+  '3' => 'ERb',
 }
 
 print_table template_engine_options.to_a, :ident => 4
 
 template_engine_selection = ask("\nOption: ", Thor::Shell::Color::BLUE)
 if template_engine_selection.present?
-  templater.template_engine.type =  template_engine_options[template_engine_selection].underscore.to_sym
+  templater.template_engine.type =  template_engine_options[template_engine_selection].downcase.to_sym
 end
 
 $stdout << "\n\n"


### PR DESCRIPTION
The name couldn't be "ERb":

ruby-1.8.7-p330 :003 > "ERb".underscore
 => "e_rb"

In templater i'm getting:

Which Template Engine would you like to use?

```
Option  Template Engine
1       Haml
2       Slim
3       ERb
```

Option:  3
/Users/guille/code/rails-templater/lib/rails_templater/template_engine.rb:12:in `type=': RailsTemplater::NotSupportedError (RailsTemplater::NotSupportedError)
