### PR TITLE
Fixed a yaml parsing problem when rubygems is updated

### DIFF
--- a/lib/template_framework/recipes/mongoid.rb
+++ b/lib/template_framework/recipes/mongoid.rb
@@ -4,6 +4,10 @@ gem 'mongoid', '2.0.0.rc.7'
 gem 'bson_ext', '~> 1.2'
 
 gsub_file 'config/application.rb', 'require "active_record/railtie"', '# require "active_record/railtie"'
+inject_into_file 'config/environment.rb', :after => "require File.expand_path('../application', __FILE__)\n" do
+  "require 'yaml'\n"
+  "YAML::ENGINE.yamler= 'syck'\n"
+end
 
 templater.post_bundler do
   generate 'mongoid:config'


### PR DESCRIPTION
This fix injects code into environment.rb that forces the use o the old syck parser, which parses the mongoid.yml file correctly.
